### PR TITLE
Gracefully handle exceptions

### DIFF
--- a/realtime_object_recognition.py
+++ b/realtime_object_recognition.py
@@ -7,37 +7,42 @@ model = tf.keras.applications.MobileNetV2(weights='imagenet')
 
 # Function to preprocess an image
 def preprocess_image(image):
-    image = tf.image.resize(image, (224, 224))
-    image = tf.keras.applications.mobilenet_v2.preprocess_input(image)
-    return image
+  image = tf.image.resize(image, (224, 224))
+  image = tf.keras.applications.mobilenet_v2.preprocess_input(image)
+  return image
 
 # Function to make predictions
 def predict_image(image):
-    image = preprocess_image(image)
-    image = np.expand_dims(image, axis=0)
-    predictions = model.predict(image)
-    decoded_predictions = tf.keras.applications.mobilenet_v2.decode_predictions(predictions.numpy())[0]
-    return decoded_predictions
+  image = preprocess_image(image)
+  image = np.expand_dims(image, axis=0)
+  predictions = model.predict(image)
+  decoded_predictions = tf.keras.applications.mobilenet_v2.decode_predictions(predictions.numpy())[0]
+  return decoded_predictions
 
 # Open a video capture stream
 cap = cv2.VideoCapture(0)
 
 while True:
-    # Capture frame-by-frame
-    ret, frame = cap.read()
+  # Capture frame-by-frame
+  ret, frame = cap.read()
 
-    # Display the frame
-    cv2.imshow('Real-time Object Recognition', frame)
+  # Check if the frame is successfully captured
+  if not ret:
+    print("Error: Failed to capture frame")
+    break
 
-    # Preprocess and make predictions
-    predictions = predict_image(frame)
+  # Display the frame
+  cv2.imshow('Real-time Object Recognition', frame)
 
-    # Print the top prediction
-    print(predictions[0][1])
+  # Preprocess and make predictions
+  predictions = predict_image(frame)
 
-    # Break the loop if 'q' is pressed
-    if cv2.waitKey(1) & 0xFF == ord('q'):
-        break
+  # Print the top prediction
+  print(predictions[0][1])
+
+  # Break the loop if 'q' is pressed
+  if cv2.waitKey(1) & 0xFF == ord('q'):
+    break
 
 # Release the video capture object
 cap.release()


### PR DESCRIPTION
If there is an issue with the video capture (`cap.read()`), it might result in errors or unexpected behavior. I think this would be a good practice to add error handling to check if the frame is successfully captured before proceeding with preprocessing and predictions. So, I added an `if` statement that breaks the loop if something goes wrong and gracefully exits the app.